### PR TITLE
minor fixes:

### DIFF
--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -203,13 +203,16 @@ class Ui(QtWidgets.QMainWindow):
                 plot.hideAxis("bottom")
 
         self.seriesSelectorSpinBox.setValue(0)
-        self.seriesSelectorSpinBox.setMaximum(num_streams)
+        self.seriesSelectorSpinBox.setMaximum(num_streams - 1)
 
     def vector_to_bit_raster(self, dat):
         nzi = np.where(dat > 0)[0]  # non-zero indices
         x = []
         y = []
-        max_bit_index = int(np.log2(max(dat)) + 1)
+        try:
+            max_bit_index = int(np.log2(max(dat)) + 1)
+        except ValueError:
+            max_bit_index = 1
         for bit_index in range(max_bit_index):
             ind = np.where(dat[nzi].astype(int) & (1 << bit_index))[0]
             x.append(np.repeat(nzi[ind], 2))
@@ -294,6 +297,11 @@ class Ui(QtWidgets.QMainWindow):
     def on_seriesVisibleCheckBox_clicked(self, checked):
         series_index = self.seriesSelectorSpinBox.value()
         self.plots[series_index].setVisible(checked)
+
+        visible_plot_indices = [i for i in range(len(self.plots)) if self.plots[i].isVisible()]
+        # make sure the last plot has an x-axis visible and the 2nd-to-last doesn't
+        self.plots[visible_plot_indices[-2]].hideAxis("bottom")
+        self.plots[visible_plot_indices[-1]].showAxis("bottom")
 
     @QtCore.pyqtSlot(int)
     def on_seriesPlotTypeComboBox_currentIndexChanged(self, index):

--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import itertools
 import importlib.resources
 import logging
 import signal
@@ -189,9 +188,8 @@ class Ui(QtWidgets.QMainWindow):
         self.plots = []
         self.plot_cursor_lines = []
         self.plot_layout.clear()
-        color_iter = itertools.cycle([self.plot_series_color] + list(range(3, 9)))
         for i in range(num_streams):
-            plot = self.plot_layout.addPlot(x=[], y=[], row=i, col=0, pen=next(color_iter))
+            plot = self.plot_layout.addPlot(x=[], y=[], row=i, col=0, pen=self.plot_series_color)
             line = pg.InfiniteLine(pos=0, angle=90, pen="red")
             plot.addItem(line)
             self.plots.append(plot)
@@ -216,7 +214,11 @@ class Ui(QtWidgets.QMainWindow):
         for bit_index in range(max_bit_index):
             ind = np.where(dat[nzi].astype(int) & (1 << bit_index))[0]
             x.append(np.repeat(nzi[ind], 2))
-            y.append(np.tile([bit_index - 0.5, bit_index + 0.5], len(ind)))
+            y.append(np.tile([bit_index - 0.4, bit_index + 0.4], len(ind)))
+        # add horizontal lines for each bit field
+        x.append(np.tile([0, len(dat)], max_bit_index))
+        y.append(np.concatenate([[i, i] for i in range(max_bit_index)]))
+
         x = np.concatenate(x)
         y = np.concatenate(y)
         return x, y


### PR DESCRIPTION
- if you hide the bottom plot, make sure new bottom plot has an x-axis.
- fix index error in series selector. you could select plot N when plots are indexed from 0:(N-1), now fixed.
- fix periodic exception thrown if ringbuffer has nans or infs when plotting bitmask