### PR TITLE
Add data-saving capabilities to splot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,16 @@ See the `LICENSE` file.
 ## Performance
 splot has been tested with 12M baud serial connections with net data rates exceeding 1 MB/sec (66% utilization). Over a TCP connection, splot can smoothly parse and plot 1.4 MB/sec of ascii data on a Macbook pro (M1).
 
-## Development
+## Saving data
+splot can save binary data or text/ascii data.
 
-### Architecture
+When receiving binary data, splot can save a file consisting of a json header including the data format (as specified as a numpy dtype string) and the data series names, followed by the binary data. It will only save complete messages; incomplete messages will be ignored. A helper function `read_serial_capture_binary` can be used to read this file and format it as a pandas dataframe, e.g.,
+```py
+import splot
+dataframe = splot.read_serial_capture_binary('/home/x/data/serialcapture_2024-06-17_17-49-54.bin')
+```
+
+When receiving ascii data, splot simply records it as a csv file.
 
 ## To-do and possible future directions
 ### To-do
@@ -58,26 +65,28 @@ There are a number of similar projects out there from which splot takes inspirat
  - https://github.com/hacknus/serial-monitor-rust
 
 ## Changelog:
- - PR #1:
-    - handle sockets, not just serial ports. you can type in a tcp/udp address into "source" and it will connect automatically.
-    - handle ascii messages with numerical fields
-    - add mouseover documentation for dtype_string
-    - in binary, message size should be inferred from dtype_string
-    - make different config options available on UI when parsing different message types
- - PR #2:
-    - Restructure as python package to allow easy install. Still works with local editable install (`pip install -e <repo path>`).
- - PR #3:
-    - Fix some bad bugs in ASCII parsing (would re-read same buffer if no new data were present! wouldnt parse floats correctly!)
-    - UI cleanup: alignment/sizing, make plot colors match system theme.
-    - Add example TCP server for testing ascii parsing.
- - PR #4:
-    - Pause didn't pause processing, just updating the plots. Pause now inhibits stream processor, so plot buffers dont update.
-    - Show vertical bar for current plot position
-    - Color scheme was bad for 'light' system theme. Now correctly pulls theme colors and uses them.
-    - Add persistent settings when closing and re-opening app via QSettings.
+- PR #8:
+    - enable saving data
 - PR #6:
     - Pause now respected when connecting/disconnecting
     - Unique colors for each plot
     - Allow disabling of certain streams for plotting
     - Remove margins between plots and x-axes of all plots except bottom one, so that plots can be bigger
     - Allow plotting of data series as rasters (interpreting values as bit-masks)
+ - PR #4:
+    - Pause didn't pause processing, just updating the plots. Pause now inhibits stream processor, so plot buffers dont update.
+    - Show vertical bar for current plot position
+    - Color scheme was bad for 'light' system theme. Now correctly pulls theme colors and uses them.
+    - Add persistent settings when closing and re-opening app via QSettings.
+ - PR #3:
+    - Fix some bad bugs in ASCII parsing (would re-read same buffer if no new data were present! wouldnt parse floats correctly!)
+    - UI cleanup: alignment/sizing, make plot colors match system theme.
+    - Add example TCP server for testing ascii parsing.
+ - PR #2:
+    - Restructure as python package to allow easy install. Still works with local editable install (`pip install -e <repo path>`).
+ - PR #1:
+    - handle sockets, not just serial ports. you can type in a tcp/udp address into "source" and it will connect automatically.
+    - handle ascii messages with numerical fields
+    - add mouseover documentation for dtype_string
+    - in binary, message size should be inferred from dtype_string
+    - make different config options available on UI when parsing different message types

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ There are a number of similar projects out there from which splot takes inspirat
 ## Changelog:
 - PR #8:
     - enable saving data
+    - revert to same color on all plots
+    - add name for each plot
+    - make names, visility, and type (analog or bitmask) of plots persistent
 - PR #6:
     - Pause now respected when connecting/disconnecting
     - Unique colors for each plot

--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ splot has been tested with 12M baud serial connections with net data rates excee
 ## Saving data
 splot can save binary data or text/ascii data.
 
-When receiving binary data, splot can save a file consisting of a json header including the data format (as specified as a numpy dtype string) and the data series names, followed by the binary data. It will only save complete messages; incomplete messages will be ignored. A helper function `read_serial_capture_binary` can be used to read this file and format it as a pandas dataframe, e.g.,
+When receiving binary data, splot can save a file consisting of a json header including the data format (as specified as a numpy dtype string) and the data series names, followed by the binary data. It will only save complete messages; incomplete messages will be ignored. A helper function `read_serial_capture_binary` can be used to read this file and format it as a structured recarray, or an (unstructured) ndarray , e.g.,
 ```py
 import splot
-dataframe = splot.read_serial_capture_binary('/home/x/data/serialcapture_2024-06-17_17-49-54.bin')
+arr, series_names = splot.read_serial_capture_binary(
+    filename='/home/x/data/serialcapture_2024-06-17_17-49-54.bin',
+    structured=True,
+)
 ```
 
 When receiving ascii data, splot simply records it as a csv file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "splot"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
   { name="Nate Cermak", email="nate.cermak@starfishneuro.com" },
 ]

--- a/src/splot/__init__.py
+++ b/src/splot/__init__.py
@@ -1,0 +1,1 @@
+from .utilities import read_serial_capture_binary  # noqa: F401

--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -192,6 +192,7 @@ class Ui(QtWidgets.QMainWindow):
             plot = self.plot_layout.addPlot(x=[], y=[], row=i, col=0, pen=self.plot_series_color)
             line = pg.InfiniteLine(pos=0, angle=90, pen="red")
             plot.addItem(line)
+            plot.setLabel("left", self.settings.value(f"ui/seriesName[{i}]"))
             self.plots.append(plot)
             self.plot_cursor_lines.append(line)
             self.plot_types.append(0)  # default to 'analog' (index 0)
@@ -294,6 +295,12 @@ class Ui(QtWidgets.QMainWindow):
         # update the series property boxes appropriately
         self.seriesVisibleCheckBox.setChecked(self.plots[series_index].isVisible())
         self.seriesPlotTypeComboBox.setCurrentIndex(self.plot_types[series_index])
+        self.seriesNameLineEdit.setText(self.plots[series_index].getAxis("left").labelText)
+
+    def on_seriesNameLineEdit_textChanged(self, text):
+        series_index = self.seriesSelectorSpinBox.value()
+        self.plots[series_index].setLabel("left", text)
+        self.settings.setValue(f"ui/seriesName[{series_index}]", text)
 
     @QtCore.pyqtSlot(bool)
     def on_seriesVisibleCheckBox_clicked(self, checked):

--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -143,7 +143,7 @@ class Ui(QtWidgets.QMainWindow):
             paused=self.pausePushButton.isChecked(),
         )
         self.serial_receiver.data_received.connect(self.stream_processor.process_new_data)
-        self.serial_receiver.data_rate.connect(self.dataRateBpsValueLabel.setNum)
+        self.serial_receiver.data_rate.connect(lambda x: self.statusBar().showMessage(f"Data rate: {x} bytes/sec"))
         self.seriesPropertyFrame.setEnabled(True)
         self.create_plot_series(num_streams=self.stream_processor.get_output_dimensions()[1])
         self.serial_receiver.start()
@@ -308,6 +308,7 @@ class Ui(QtWidgets.QMainWindow):
         self.seriesPlotTypeComboBox.setCurrentIndex(self.plot_types[series_index])
         self.seriesNameLineEdit.setText(self.plots[series_index].getAxis("left").labelText)
 
+    @QtCore.pyqtSlot(str)
     def on_seriesNameLineEdit_textChanged(self, text):
         series_index = self.seriesSelectorSpinBox.value()
         self.plots[series_index].setLabel("left", text)
@@ -329,6 +330,11 @@ class Ui(QtWidgets.QMainWindow):
         series_index = self.seriesSelectorSpinBox.value()
         self.plot_types[series_index] = index
         self.settings.setValue(f"ui/seriesPlotType[{series_index}]", index)
+
+    @QtCore.pyqtSlot()
+    def on_setSaveLocationPushButton_clicked(self):
+        directory = QtWidgets.QFileDialog.getExistingDirectory()
+        self.saveLocationLabel.setText("Save to: " + directory)
 
     @QtCore.pyqtSlot(int)
     def on_plotLengthSpinBox_valueChanged(self, plot_buffer_length):

--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -228,7 +228,6 @@ class Ui(QtWidgets.QMainWindow):
     def vector_to_bit_raster(self, dat):
         x = []
         y = []
-
         # analyze only non-zero indices for speed (sparsity assumption)
         non_zero_indices = np.where(dat > 0)[0]
         try:

--- a/src/splot/splot.ui
+++ b/src/splot/splot.ui
@@ -548,16 +548,30 @@
                    <property name="text">
                     <string>Save data</string>
                    </property>
+                   <property name="checkable">
+                    <bool>true</bool>
+                   </property>
                   </widget>
                  </item>
                 </layout>
                </item>
                <item>
-                <widget class="QLabel" name="saveLocationLabel">
-                 <property name="text">
-                  <string>(None)</string>
-                 </property>
-                </widget>
+                <layout class="QFormLayout" name="formLayout_5">
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="saveToLabel">
+                   <property name="text">
+                    <string>Save to:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QLabel" name="saveLocationLabel">
+                   <property name="text">
+                    <string>(None)</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </item>
               </layout>
              </widget>

--- a/src/splot/splot.ui
+++ b/src/splot/splot.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>790</width>
-    <height>619</height>
+    <height>680</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -155,6 +155,9 @@
             </size>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_2">
+            <property name="spacing">
+             <number>4</number>
+            </property>
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -186,7 +189,7 @@
                 <enum>QFormLayout::ExpandingFieldsGrow</enum>
                </property>
                <property name="verticalSpacing">
-                <number>5</number>
+                <number>4</number>
                </property>
                <property name="leftMargin">
                 <number>12</number>
@@ -334,7 +337,7 @@
                 <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
                </property>
                <property name="verticalSpacing">
-                <number>5</number>
+                <number>4</number>
                </property>
                <item row="0" column="0">
                 <widget class="QLabel" name="label_13">
@@ -444,6 +447,9 @@
                <property name="fieldGrowthPolicy">
                 <enum>QFormLayout::ExpandingFieldsGrow</enum>
                </property>
+               <property name="verticalSpacing">
+                <number>4</number>
+               </property>
                <item row="0" column="0">
                 <widget class="QLabel" name="seriesLabel">
                  <property name="text">
@@ -461,14 +467,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="2" column="0">
+               <item row="3" column="0">
                 <widget class="QLabel" name="seriesPlotTypeLabel">
                  <property name="text">
                   <string>Plot type</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="1">
+               <item row="3" column="1">
                 <widget class="QComboBox" name="seriesPlotTypeComboBox">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -488,14 +494,14 @@
                  </item>
                 </widget>
                </item>
-               <item row="1" column="0">
+               <item row="2" column="0">
                 <widget class="QLabel" name="seriesVisibleLabel">
                  <property name="text">
                   <string>Visible?</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="1">
+               <item row="2" column="1">
                 <widget class="QCheckBox" name="seriesVisibleCheckBox">
                  <property name="enabled">
                   <bool>true</bool>
@@ -504,6 +510,16 @@
                   <bool>true</bool>
                  </property>
                 </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="seriesNameLabel">
+                 <property name="text">
+                  <string>Name</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="seriesNameLineEdit"/>
                </item>
               </layout>
              </widget>

--- a/src/splot/splot.ui
+++ b/src/splot/splot.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>790</width>
-    <height>680</height>
+    <height>725</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -107,26 +107,6 @@
               <string>(not connected)</string>
              </property>
             </item>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="dataRateBpsLabel">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Data rate:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="dataRateBpsValueLabel">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>---</string>
-            </property>
            </widget>
           </item>
          </layout>
@@ -267,6 +247,28 @@
                  </property>
                 </widget>
                </item>
+               <item row="4" column="1">
+                <widget class="QSpinBox" name="serialReadChunkSizeSpinBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="minimum">
+                  <number>1</number>
+                 </property>
+                 <property name="maximum">
+                  <number>99999999</number>
+                 </property>
+                 <property name="value">
+                  <number>10000</number>
+                 </property>
+                </widget>
+               </item>
                <item row="5" column="0">
                 <widget class="QLabel" name="serialBufferSizeLabel">
                  <property name="text">
@@ -293,28 +295,6 @@
                  </property>
                  <property name="value">
                   <number>100000</number>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="QSpinBox" name="serialReadChunkSizeSpinBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="keyboardTracking">
-                  <bool>false</bool>
-                 </property>
-                 <property name="minimum">
-                  <number>1</number>
-                 </property>
-                 <property name="maximum">
-                  <number>99999999</number>
-                 </property>
-                 <property name="value">
-                  <number>10000</number>
                  </property>
                 </widget>
                </item>
@@ -520,6 +500,64 @@
                </item>
                <item row="1" column="1">
                 <widget class="QLineEdit" name="seriesNameLineEdit"/>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QFrame" name="saveFrame">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout">
+               <property name="spacing">
+                <number>4</number>
+               </property>
+               <item>
+                <layout class="QFormLayout" name="formLayout_3">
+                 <property name="fieldGrowthPolicy">
+                  <enum>QFormLayout::ExpandingFieldsGrow</enum>
+                 </property>
+                 <property name="verticalSpacing">
+                  <number>0</number>
+                 </property>
+                 <item row="0" column="0">
+                  <widget class="QPushButton" name="setSaveLocationPushButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Set save loc.</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QPushButton" name="savePushButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Save data</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QLabel" name="saveLocationLabel">
+                 <property name="text">
+                  <string>(None)</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>

--- a/src/splot/stream_processor.py
+++ b/src/splot/stream_processor.py
@@ -39,7 +39,9 @@ class StreamProcessor:
 
         if self.binary:
             self.binary_dtype = np.dtype(binary_dtype_string)
-            num_streams = len(self.binary_dtype) - 1
+
+            num_streams = np.sum([1 if len(x) <= 2 else np.prod(x[2]) for x in self.binary_dtype.descr])
+            num_streams -= 1  # subtract one to ignore header byte
             self.message_delimiter = int(message_delimiter) % 256
         else:
             num_streams = ascii_num_streams

--- a/src/splot/stream_processor.py
+++ b/src/splot/stream_processor.py
@@ -73,10 +73,10 @@ class StreamProcessor:
 
     def process_new_data(self):
         """This slot should be connected to serial_receiver's data_received signal."""
-        # get new data
         if self.paused:
             return
 
+        # get new data
         new_data = self.serial_receiver.get_new_data(self.read_ptr)
         num_bytes_read = len(new_data)
 
@@ -146,6 +146,12 @@ class StreamProcessor:
             data = rfn.structured_to_unstructured(data)
             data = data[:, 1:]  # drop 1st column, it's the delimiter which is constant by definition
 
+            # if we're saving to file, dump new data to file here
+            # - avro
+            # - straight binary
+            # - csv
+
+            # update ring-buffer that plot UI will use
             n = len(messages)
             if n >= self.plot_buffer.shape[0]:
                 # If data is larger than plot_buffer, just overwrite the whole buffer with the most recent data

--- a/src/splot/utilities.py
+++ b/src/splot/utilities.py
@@ -1,0 +1,37 @@
+import json
+import numpy as np
+from numpy.lib import recfunctions as rfn
+
+
+def read_serial_capture_binary(filename, structured=False):
+    """Load a splot serial_capture data file, which begins with a json header,
+    immediately followed by binary data (in the format specified in the header).
+
+    Returns:
+        a list containing:
+         - either a structured numpy recarray (if structured==True), or a
+        regular ndarray (structured==False).
+         - the names of the individual scalar fields
+    """
+
+    with open(filename, "rb") as file:
+        # assume header can't be longer than 4kb
+        chunk_string = file.read(4096).decode("utf-8", errors="ignore")
+        decoder = json.JSONDecoder()
+        json_object, binary_start_index = decoder.raw_decode(chunk_string)
+
+        binary_dtype = np.dtype(json_object["dtype_string"])
+        columns = ["delimiter"] + json_object["series_names"]
+        columns = [name if name != "" else f"var{i}" for i, name in enumerate(columns)]
+
+        file.seek(binary_start_index)
+        structured_data = np.fromfile(file, binary_dtype)
+
+    if structured:
+        return structured_data, columns
+
+    # flatten a potentially nested data type down to scalars
+    data = rfn.structured_to_unstructured(structured_data)
+    data = data[:, 1:]  # drop 1st column, it's the delimiter which is constant by definition
+
+    return data, columns


### PR DESCRIPTION
- if receiving binary data, save complete binary messages into a file with a json header that includes the dtype string necessary for parsing that data, as well as the variable names
- add a utility function to read back the binary data
- if receiving ascii data, save the numbers into a csv file. the header is variable names (empty strings if not set).
