### PR TITLE
Update stream processor from UI while connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ arr, series_names = splot.read_serial_capture_binary(
 
 When receiving ascii data, splot simply records it as a csv file.
 
-## To-do and possible future directions
-### To-do
-- Changing data formats doesnt work while connected, it only takes effect when upon connection. Fix this.
-
 ### Possible future directions
 - Development:
     - Implementing a good test infrastructure for automated testing (possibly in CI)
@@ -68,6 +64,8 @@ There are a number of similar projects out there from which splot takes inspirat
  - https://github.com/hacknus/serial-monitor-rust
 
 ## Changelog:
+- PR #14:
+    - Changing data formats didn't work while connected, but works now.
 - PR #8:
     - enable saving data
     - revert to same color on all plots

--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -318,14 +318,14 @@ class Ui(QtWidgets.QMainWindow):
     def on_dataFormatComboBox_currentIndexChanged(self, index):
         self.settings.setValue("ui/dataFormatIndex", index)
         binary = index == 0
-        self.binaryDtypeStringLineEdit.setVisible(binary)
-        self.binaryDtypeStringLabel.setVisible(binary)
-        self.numberOfStreamsLabel.setVisible(not binary)
-        self.numberOfStreamsSpinBox.setVisible(not binary)
-        self.binaryMessageDelimiterSpinBox.setVisible(binary)
-        self.binaryMessageDelimiterLabel.setVisible(binary)
-        self.asciiMessageDelimiterLineEdit.setVisible(not binary)
-        self.asciiMessageDelimiterLabel.setVisible(not binary)
+        self.binaryDtypeStringLineEdit.setEnabled(binary)
+        self.binaryDtypeStringLabel.setEnabled(binary)
+        self.numberOfStreamsLabel.setEnabled(not binary)
+        self.numberOfStreamsSpinBox.setEnabled(not binary)
+        self.binaryMessageDelimiterSpinBox.setEnabled(binary)
+        self.binaryMessageDelimiterLabel.setEnabled(binary)
+        self.asciiMessageDelimiterLineEdit.setEnabled(not binary)
+        self.asciiMessageDelimiterLabel.setEnabled(not binary)
 
         if self.stream_processor is not None:
             if binary:

--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -42,10 +42,9 @@ class Ui(QtWidgets.QMainWindow):
         self.socket = None  # keep these around to properly close them
         self.serial_connection = None
 
-        # timer to update plots at 30 Hz
+        # timer to update plots
         self.plot_timer = QtCore.QTimer()
         self.plot_timer.timeout.connect(self.update_stream_plots)
-        self.plot_timer.start(33)
 
         # set plot background and color based on system theme
         palette = QtWidgets.QApplication.palette()
@@ -155,16 +154,23 @@ class Ui(QtWidgets.QMainWindow):
         self.create_plot_series(num_streams=self.stream_processor.get_output_dimensions()[1])
         self.serial_receiver.start()
         self.enable_ui_elements_on_connection(connected=True)
+        self.plot_timer.start(33)
 
     def disconnect_from_serial(self):
+        self.plot_timer.stop()
+        if self.stream_processor is not None:
+            self.stream_processor = None
+
         if self.serial_receiver is not None:
             self.serial_receiver.stop()
             self.serial_receiver.wait()
             self.serial_receiver.disconnect()  # disconnect all slots
             self.serial_receiver = None
             self.serial_connection.close()
+
         if self.socket is not None:
             self.socket.close()
+
         self.savePushButton.setChecked(False)
         self.enable_ui_elements_on_connection(connected=False)
         self.statusBar().showMessage("Disconnected.")
@@ -308,18 +314,39 @@ class Ui(QtWidgets.QMainWindow):
         self.binaryDtypeStringLabel.setVisible(binary)
         self.numberOfStreamsLabel.setVisible(not binary)
         self.numberOfStreamsSpinBox.setVisible(not binary)
+        if self.stream_processor:
+            if binary:
+                self.stream_processor.set_binary_mode(
+                    binary_dtype_string=self.binaryDtypeStringLineEdit.text(),
+                    message_delimiter=int(self.messageDelimiterLineEdit.text()),
+                )
+            else:
+                self.stream_processor.set_ascii_mode(
+                    ascii_num_streams=self.numberOfStreamsSpinBox.value(),
+                    message_delimiter=self.messageDelimiterLineEdit.text(),
+                )
 
-    @QtCore.pyqtSlot(str)
-    def on_messageDelimiterLineEdit_textEdited(self, value):
+    @QtCore.pyqtSlot()
+    def on_messageDelimiterLineEdit_editingFinished(self):
+        value = self.messageDelimiterLineEdit.text()
         self.settings.setValue("ui/messageDelimiter", value)
+        if self.stream_processor is not None:
+            self.stream_processor.set_message_delimiter(value)
 
-    @QtCore.pyqtSlot(str)
-    def on_binaryDtypeStringLineEdit_textEdited(self, value):
+    @QtCore.pyqtSlot()
+    def on_binaryDtypeStringLineEdit_editingFinished(self):
+        value = self.binaryDtypeStringLineEdit.text()
         self.settings.setValue("ui/binaryDtypeString", value)
+        if self.stream_processor is not None:
+            self.stream_processor.set_binary_dtype(value)
 
     @QtCore.pyqtSlot(int)
     def on_numberOfStreamsSpinBox_valueChanged(self, value):
         self.settings.setValue("ui/numberOfStreams", value)
+        self.stream_processor.set_ascii_mode(
+            ascii_num_streams=value,
+            message_delimiter=self.messageDelimiterLineEdit.text(),
+        )
 
     @QtCore.pyqtSlot(int)
     def on_seriesSelectorSpinBox_valueChanged(self, series_index):
@@ -406,9 +433,9 @@ class Ui(QtWidgets.QMainWindow):
         if self.stream_processor is not None:
             self.stream_processor.paused = checked
         if checked:
-            self.plot_timer.timeout.disconnect(self.update_stream_plots)
+            self.plot_timer.stop()
         else:
-            self.plot_timer.timeout.connect(self.update_stream_plots)
+            self.plot_timer.start(33)
 
 
 def main():

--- a/src/splot/splot.ui
+++ b/src/splot/splot.ui
@@ -347,27 +347,30 @@
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="asciiMessageDelimiterLabel">
+                <widget class="QLabel" name="binaryMessageDelimiterLabel">
                  <property name="text">
-                  <string>ASCII separator</string>
+                  <string>Separator byte</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="1">
-                <widget class="QLineEdit" name="asciiMessageDelimiterLineEdit">
-                 <property name="text">
-                  <string>\n</string>
+                <widget class="QSpinBox" name="binaryMessageDelimiterSpinBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="0">
+               <item row="2" column="0">
                 <widget class="QLabel" name="binaryDtypeStringLabel">
                  <property name="text">
                   <string>Binary format</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
+               <item row="2" column="1">
                 <widget class="QLineEdit" name="binaryDtypeStringLineEdit">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -383,6 +386,20 @@
                  </property>
                  <property name="text">
                   <string>u1,u1,u2,u2,u2</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="asciiMessageDelimiterLabel">
+                 <property name="text">
+                  <string>ASCII separator</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QLineEdit" name="asciiMessageDelimiterLineEdit">
+                 <property name="text">
+                  <string>\n</string>
                  </property>
                 </widget>
                </item>
@@ -406,23 +423,6 @@
                  </property>
                  <property name="minimum">
                   <number>1</number>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="binaryMessageDelimiterLabel">
-                 <property name="text">
-                  <string>Separator byte</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <widget class="QSpinBox" name="binaryMessageDelimiterSpinBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
                  </property>
                 </widget>
                </item>

--- a/src/splot/splot.ui
+++ b/src/splot/splot.ui
@@ -347,27 +347,27 @@
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="messageDelimiterLabel">
+                <widget class="QLabel" name="asciiMessageDelimiterLabel">
                  <property name="text">
-                  <string>Separator</string>
+                  <string>ASCII separator</string>
                  </property>
                 </widget>
                </item>
                <item row="1" column="1">
-                <widget class="QLineEdit" name="messageDelimiterLineEdit">
+                <widget class="QLineEdit" name="asciiMessageDelimiterLineEdit">
                  <property name="text">
-                  <string>0</string>
+                  <string>\n</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="0">
+               <item row="3" column="0">
                 <widget class="QLabel" name="binaryDtypeStringLabel">
                  <property name="text">
                   <string>Binary format</string>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="1">
+               <item row="3" column="1">
                 <widget class="QLineEdit" name="binaryDtypeStringLineEdit">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -386,14 +386,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="3" column="0">
+               <item row="4" column="0">
                 <widget class="QLabel" name="numberOfStreamsLabel">
                  <property name="text">
                   <string>Number of streams</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
+               <item row="4" column="1">
                 <widget class="QSpinBox" name="numberOfStreamsSpinBox">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -406,6 +406,23 @@
                  </property>
                  <property name="minimum">
                   <number>1</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="binaryMessageDelimiterLabel">
+                 <property name="text">
+                  <string>Separator byte</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QSpinBox" name="binaryMessageDelimiterSpinBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
                  </property>
                 </widget>
                </item>

--- a/src/splot/stream_processor.py
+++ b/src/splot/stream_processor.py
@@ -40,18 +40,12 @@ class StreamProcessor:
         self.save_file = None  # handle to file for saving data
         self.csv_writer = None
 
+        self.plot_buffer = np.full((plot_buffer_length, 1), np.nan, dtype=float)
+
         if self.binary:
-            self.binary_dtype = np.dtype(binary_dtype_string)
-
-            num_streams = np.sum([1 if len(x) <= 2 else np.prod(x[2]) for x in self.binary_dtype.descr])
-            num_streams -= 1  # subtract one to ignore header byte
-            self.message_delimiter = int(message_delimiter) % 256
+            self.set_binary_mode(binary_dtype_string, message_delimiter)
         else:
-            num_streams = ascii_num_streams
-            # process escape characters correctly
-            self.message_delimiter = bytes(message_delimiter, "utf-8").decode("unicode_escape")
-
-        self.plot_buffer = np.full((plot_buffer_length, num_streams), np.nan, dtype=float)
+            self.set_ascii_mode(ascii_num_streams, message_delimiter)
 
         # compile regex to parse numbers out of arbitrary strings
         numeric_const_pattern = r"[-+]? (?: (?: \d* \. \d+ ) | (?: \d+ \.? ) )(?: [Ee] [+-]? \d+ ) ?"
@@ -61,15 +55,37 @@ class StreamProcessor:
         self.plot_buffer = np.full((size, self.plot_buffer.shape[1]), np.nan, dtype=float)
         self.write_ptr = 0
 
-    def change_binary_dtype(self, dtype_string):
+    def set_binary_dtype(self, binary_dtype_string):
+        if not self.binary:
+            return
+
         try:
-            dt = np.dtype(dtype_string)
+            self.binary_dtype = np.dtype(binary_dtype_string)
+            num_streams = np.sum([1 if len(x) <= 2 else np.prod(x[2]) for x in self.binary_dtype.descr])
+            num_streams -= 1  # subtract one to ignore header byte
             # changing dtype probably changes number of fields; wipe buffer and make it the right size
-            self.plot_buffer = np.full((self.plot_buffer.shape[0], len(dt) - 1), np.nan, dtype=float)
+            self.plot_buffer = np.full((self.plot_buffer.shape[0], num_streams), np.nan, dtype=float)
             self.write_ptr = 0
-            self.binary_dtype = dt
         except Exception as e:
-            logger.error(f'Failed to set binary data format "{dtype_string}".\n{e}')
+            logger.error(f'Failed to set binary data format "{binary_dtype_string}".\n{e}')
+
+    def set_message_delimiter(self, message_delimiter):
+        if self.binary:
+            self.message_delimiter = int(message_delimiter) % 256
+        else:
+            self.message_delimiter = bytes(message_delimiter, "utf-8").decode("unicode_escape")
+
+    def set_binary_mode(self, binary_dtype_string: str, message_delimiter: int):
+        self.binary = True
+        self.set_message_delimiter(message_delimiter)
+        self.set_binary_dtype(binary_dtype_string)
+
+    def set_ascii_mode(self, ascii_num_streams, message_delimiter: str):
+        self.binary = False
+        self.set_message_delimiter(message_delimiter)
+
+        self.plot_buffer = np.full((self.plot_buffer.shape[0], ascii_num_streams), np.nan, dtype=float)
+        self.write_ptr = 0
 
     def get_output_dimensions(self):
         return self.plot_buffer.shape

--- a/test/example_ascii_server.py
+++ b/test/example_ascii_server.py
@@ -3,7 +3,7 @@ import numpy as np
 import time
 
 server_socket = socket.socket()
-server_socket.bind(('localhost', 12345))
+server_socket.bind(("localhost", 12345))
 server_socket.listen()
 while True:
     conn, address = server_socket.accept()  # accept new connection
@@ -11,16 +11,16 @@ while True:
     while True:
         x1 = np.random.rand() - 0.5
         x2 = np.sin(time.time() * 100)
-        x3 = np.sin(time.time() * 10) + 0.1*x1
+        x3 = np.sin(time.time() * 10) + 0.1 * x1
         x4 = round(time.time() * 10) % 2
         data = f"{counter}, {x1}, {x2:.5e}units {x3} junk {x4}\r\n"
 
         try:
-            conn.send(data.encode('ascii'))
+            conn.send(data.encode("ascii"))
         except Exception as e:
             print(e)
             break
 
-        #print(f"Sent: {data}")
+        # print(f"Sent: {data}")
         counter += 1
-        time.sleep(.00005)
+        time.sleep(0.00005)

--- a/test/example_binary_server.py
+++ b/test/example_binary_server.py
@@ -1,0 +1,34 @@
+import socket
+import numpy as np
+import time
+
+server_socket = socket.socket()
+server_socket.bind(("localhost", 12344))
+server_socket.listen()
+while True:
+    conn, address = server_socket.accept()  # accept new connection
+    counter = 0
+    while True:
+        delimiter = 42
+        x1 = int(np.random.rand() * 255)
+        x2 = int(np.sin(time.time() * 1) * 2**15)
+        x3 = int(np.sin(time.time() * 10) * 2**15)
+        x4 = int(np.sin(time.time() * 100) * 2**15)
+        x5 = x1 + x2 + x3 + x4
+
+        # u1, u1, 3i2, i4
+        data = delimiter.to_bytes(1) + x1.to_bytes(1)
+        data += x2.to_bytes(2, signed=True, byteorder="little")
+        data += x3.to_bytes(2, signed=True, byteorder="little")
+        data += x4.to_bytes(2, signed=True, byteorder="little")
+        data += x5.to_bytes(4, signed=True, byteorder="little")
+
+        try:
+            conn.send(data)
+        except Exception as e:
+            print(e)
+            break
+
+        # print(f"Sent: {data}")
+        counter += 1
+        time.sleep(0.00005)


### PR DESCRIPTION
Overall I'm on the fence about this -- this seems a little too complicated and trying to handle too many cases. It might have been cleaner to just force the user to disconnect (and create an entirely new StreamProcessor object) if they want to change these parameters. That said, everything seems to work correctly now.

Summary of changes:
- split "delimiter" LineEdit into two separate UI items, one for ascii (still a LineEdit) and one for binary (a SpinBox)
- depending on ascii/binary combobox, enable/disable appropriate UI items
- update stream processor to respond to changes in ascii/binary combobox, delimiter, binary message type, and number of ascii streams
- on pause, just start and stop timer, don't disconnect slot for updating plots
- on disconnect, stop timer for updating plots
- add additional test server on adjacent port, emitting binary data
