### PR TITLE
Add ZMQ plumbing to both receive (ZMQ SUB: forward rcv'd data to serial) and emit serial data (ZMQ PUB)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "pyqt6>=6.5",
   "pyqtgraph>=0.13.3",
   "pyserial>=3.5",
+  "pyzmq>=26.0",
 ]
 license = {file = "LICENSE"}
 

--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -473,7 +473,7 @@ class Ui(QtWidgets.QMainWindow):
             # pass conn to serial receiver
             if self.serial_receiver:
                 self.serial_receiver.forward_conn = conn
-        if not checked:
+        elif not checked:
             if self.serial_receiver:
                 self.serial_receiver.forward_conn = None
 
@@ -497,7 +497,7 @@ class Ui(QtWidgets.QMainWindow):
             self.zmq_listener_thread = threading.Thread(target=self.zmq_listener_loop, args=(conn,))
             self.zmq_listener_thread.start()
 
-        if not checked:
+        elif not checked:
             # tear down listener loop thread if it exists
             self.zmq_listener_loop_running = False
             if self.zmq_listener_thread:

--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -104,6 +104,8 @@ class Ui(QtWidgets.QMainWindow):
             "ui/binaryMessageDelimiter": lambda x: self.binaryMessageDelimiterSpinBox.setValue(int(x)),
             "ui/binaryDtypeString": self.binaryDtypeStringLineEdit.setText,
             "ui/plotLength": lambda x: self.plotLengthSpinBox.setValue(int(x)),
+            "ui/zmqReceiveDataPort": lambda x: self.receiveDataPortSpinBox.setValue(int(x)),
+            "ui/zmqEmitDataPort": lambda x: self.emitDataPortSpinBox.setValue(int(x)),
         }
         for key, set_function in settings_map.items():
             value = self.settings.value(key)
@@ -452,6 +454,14 @@ class Ui(QtWidgets.QMainWindow):
                 self.stream_processor.save_file = None
                 self.save_file.close()
                 self.save_file = None
+
+    @QtCore.pyqtSlot(int)
+    def on_receiveDataPortSpinBox_valueChanged(self, value):
+        self.settings.setValue("ui/zmqReceiveDataPort", value)
+
+    @QtCore.pyqtSlot(int)
+    def on_emitDataPortSpinBox_valueChanged(self, value):
+        self.settings.setValue("ui/zmqEmitDataPort", value)
 
     @QtCore.pyqtSlot(bool)
     def on_emitDataCheckBox_clicked(self, checked):

--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -79,6 +79,7 @@ class Ui(QtWidgets.QMainWindow):
 
         self.zmq_listener_thread = None
         self.zmq_listener_loop_running = False
+        self.zmq_emitter_conn = None
 
     def populate_serial_options(self):
         option_map = {
@@ -148,6 +149,7 @@ class Ui(QtWidgets.QMainWindow):
             read_function=read_function,
             buffer_length=self.serialBufferSizeSpinBox.value(),
             read_chunk_size=self.serialReadChunkSizeSpinBox.value(),
+            forward_conn=self.zmq_emitter_conn,
         )
         binary = self.dataFormatComboBox.currentText() == "binary"
         if binary:
@@ -468,11 +470,11 @@ class Ui(QtWidgets.QMainWindow):
         self.emitDataPortSpinBox.setEnabled(not checked)
         if checked:
             port = self.emitDataPortSpinBox.value()
-            conn = zmq.Context().socket(zmq.PUB)
-            conn.bind(f"tcp://*:{port}")
+            self.zmq_emitter_conn = zmq.Context().socket(zmq.PUB)
+            self.zmq_emitter_conn.bind(f"tcp://*:{port}")
             # pass conn to serial receiver
             if self.serial_receiver:
-                self.serial_receiver.forward_conn = conn
+                self.serial_receiver.forward_conn = self.zmq_emitter_conn
         elif not checked:
             if self.serial_receiver:
                 self.serial_receiver.forward_conn = None

--- a/src/splot/splot.ui
+++ b/src/splot/splot.ui
@@ -433,101 +433,6 @@
              </widget>
             </item>
             <item>
-             <widget class="QFrame" name="seriesPropertyFrame">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
-              </property>
-              <property name="frameShadow">
-               <enum>QFrame::Raised</enum>
-              </property>
-              <layout class="QFormLayout" name="formLayout_2">
-               <property name="fieldGrowthPolicy">
-                <enum>QFormLayout::ExpandingFieldsGrow</enum>
-               </property>
-               <property name="verticalSpacing">
-                <number>4</number>
-               </property>
-               <item row="0" column="0">
-                <widget class="QLabel" name="seriesLabel">
-                 <property name="text">
-                  <string>Series</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QSpinBox" name="seriesSelectorSpinBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="correctionMode">
-                  <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="seriesPlotTypeLabel">
-                 <property name="text">
-                  <string>Plot type</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="1">
-                <widget class="QComboBox" name="seriesPlotTypeComboBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <item>
-                  <property name="text">
-                   <string>Analog</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Bit mask</string>
-                  </property>
-                 </item>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="seriesVisibleLabel">
-                 <property name="text">
-                  <string>Visible?</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <widget class="QCheckBox" name="seriesVisibleCheckBox">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="seriesNameLabel">
-                 <property name="text">
-                  <string>Name</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QLineEdit" name="seriesNameLineEdit"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
              <widget class="QFrame" name="saveFrame">
               <property name="frameShape">
                <enum>QFrame::StyledPanel</enum>
@@ -673,6 +578,101 @@
                </size>
               </property>
              </spacer>
+            </item>
+            <item>
+             <widget class="QFrame" name="seriesPropertyFrame">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QFormLayout" name="formLayout_2">
+               <property name="fieldGrowthPolicy">
+                <enum>QFormLayout::ExpandingFieldsGrow</enum>
+               </property>
+               <property name="verticalSpacing">
+                <number>4</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QLabel" name="seriesLabel">
+                 <property name="text">
+                  <string>Series</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QSpinBox" name="seriesSelectorSpinBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="correctionMode">
+                  <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QLabel" name="seriesPlotTypeLabel">
+                 <property name="text">
+                  <string>Plot type</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QComboBox" name="seriesPlotTypeComboBox">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <item>
+                  <property name="text">
+                   <string>Analog</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Bit mask</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QLabel" name="seriesVisibleLabel">
+                 <property name="text">
+                  <string>Visible?</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QCheckBox" name="seriesVisibleCheckBox">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="seriesNameLabel">
+                 <property name="text">
+                  <string>Name</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLineEdit" name="seriesNameLineEdit"/>
+               </item>
+              </layout>
+             </widget>
             </item>
             <item>
              <widget class="QFrame" name="frame">

--- a/src/splot/splot.ui
+++ b/src/splot/splot.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>790</width>
-    <height>725</height>
+    <height>836</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -462,6 +462,9 @@
                    <verstretch>0</verstretch>
                   </sizepolicy>
                  </property>
+                 <property name="correctionMode">
+                  <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+                 </property>
                 </widget>
                </item>
                <item row="3" column="0">
@@ -529,66 +532,122 @@
               <property name="frameShadow">
                <enum>QFrame::Raised</enum>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout">
-               <property name="spacing">
-                <number>4</number>
-               </property>
-               <item>
-                <layout class="QFormLayout" name="formLayout_3">
-                 <property name="fieldGrowthPolicy">
-                  <enum>QFormLayout::ExpandingFieldsGrow</enum>
+              <layout class="QGridLayout" name="gridLayout_2">
+               <item row="0" column="0" colspan="2">
+                <widget class="QPushButton" name="setSaveLocationPushButton">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
                  </property>
-                 <property name="verticalSpacing">
-                  <number>0</number>
+                 <property name="text">
+                  <string>Set save loc.</string>
                  </property>
-                 <item row="0" column="0">
-                  <widget class="QPushButton" name="setSaveLocationPushButton">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>Set save loc.</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QPushButton" name="savePushButton">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>Save data</string>
-                   </property>
-                   <property name="checkable">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+                </widget>
                </item>
-               <item>
-                <layout class="QFormLayout" name="formLayout_5">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="saveToLabel">
-                   <property name="text">
-                    <string>Save to:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLabel" name="saveLocationLabel">
-                   <property name="text">
-                    <string>(None)</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+               <item row="0" column="2">
+                <widget class="QPushButton" name="savePushButton">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Save data</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="saveToLabel">
+                 <property name="text">
+                  <string>Save to:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1" colspan="2">
+                <widget class="QLabel" name="saveLocationLabel">
+                 <property name="text">
+                  <string>(None)</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QFrame" name="zmqFrame">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>10</height>
+               </size>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <layout class="QGridLayout" name="gridLayout">
+               <property name="horizontalSpacing">
+                <number>-1</number>
+               </property>
+               <property name="verticalSpacing">
+                <number>0</number>
+               </property>
+               <item row="1" column="1">
+                <widget class="QSpinBox" name="receiveDataPortSpinBox">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="buttonSymbols">
+                  <enum>QAbstractSpinBox::NoButtons</enum>
+                 </property>
+                 <property name="maximum">
+                  <number>65535</number>
+                 </property>
+                 <property name="value">
+                  <number>5679</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QCheckBox" name="emitDataCheckBox">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="text">
+                  <string>Emit data on port:</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QSpinBox" name="emitDataPortSpinBox">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="buttonSymbols">
+                  <enum>QAbstractSpinBox::NoButtons</enum>
+                 </property>
+                 <property name="maximum">
+                  <number>65535</number>
+                 </property>
+                 <property name="value">
+                  <number>5678</number>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QCheckBox" name="receiveDataCheckBox">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="text">
+                  <string>Receive data on port:</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>

--- a/src/splot/splot.ui
+++ b/src/splot/splot.ui
@@ -361,6 +361,9 @@
                    <verstretch>0</verstretch>
                   </sizepolicy>
                  </property>
+                 <property name="maximum">
+                  <number>255</number>
+                 </property>
                 </widget>
                </item>
                <item row="2" column="0">
@@ -605,6 +608,9 @@
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::NoButtons</enum>
                  </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
                  <property name="maximum">
                   <number>65535</number>
                  </property>
@@ -630,6 +636,9 @@
                  </property>
                  <property name="buttonSymbols">
                   <enum>QAbstractSpinBox::NoButtons</enum>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
                  </property>
                  <property name="maximum">
                   <number>65535</number>
@@ -723,7 +732,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QFrame" name="verticalFrame">
+          <widget class="QFrame" name="rightFrame">
            <property name="frameShape">
             <enum>QFrame::StyledPanel</enum>
            </property>


### PR DESCRIPTION
It is often useful to allow multiple access on a serial port. This PR allows splot to provide multiple access via ZMQ. splot can publish serial data on a given local port, and can allow publishers to connect and send data to the serial device. This occurs via a separate thread that just busywaits for zmq messages, and if its receives any, dumps them into the serial. 