### PR TITLE
Minor UI tweaks

### DIFF
--- a/src/splot/raw_data_viewer.py
+++ b/src/splot/raw_data_viewer.py
@@ -35,6 +35,7 @@ class RawDataViewer(QtWidgets.QWidget):
         self.clear_button = QtWidgets.QPushButton("Clear")
         self.clear_button.setCheckable(False)
         self.clear_button.clicked.connect(clear_data_function)
+
         h_layout.addWidget(self.clear_button)
 
         self.text_edit = QtWidgets.QTextEdit()
@@ -44,6 +45,8 @@ class RawDataViewer(QtWidgets.QWidget):
         self.timer = QtCore.QTimer()
         self.timer.timeout.connect(self.update_text_box)
         self.timer.start(self.update_interval_ms)
+
+        self.clear_button.clicked.connect(self.text_edit.clear)
 
     def update_text_box(self):
         data = self.get_data_function()  # returns bytes

--- a/src/splot/splot.py
+++ b/src/splot/splot.py
@@ -140,6 +140,9 @@ class Ui(QtWidgets.QMainWindow):
 
         self.raw_data_viewer = None
 
+        self.transmitDataLineEdit.returnPressed.connect(self.transmit_serial_data)
+        self.transmitDataPushButton.clicked.connect(self.transmit_serial_data)
+
     def populate_serial_options(self):
         option_map = {
             self.serialBaudRateComboBox: serial.serialutil.SerialBase.BAUDRATES,
@@ -443,8 +446,10 @@ class Ui(QtWidgets.QMainWindow):
 
         visible_plot_indices = [i for i in range(len(self.plots)) if self.plots[i].isVisible()]
         # make sure the last plot has an x-axis visible and the 2nd-to-last doesn't
-        self.plots[visible_plot_indices[-2]].hideAxis("bottom")
-        self.plots[visible_plot_indices[-1]].showAxis("bottom")
+        if len(visible_plot_indices) > 1:
+            self.plots[visible_plot_indices[-2]].hideAxis("bottom")
+        if len(visible_plot_indices):
+            self.plots[visible_plot_indices[-1]].showAxis("bottom")
 
     @QtCore.pyqtSlot(int)
     def on_seriesPlotTypeComboBox_currentIndexChanged(self, index):
@@ -505,13 +510,13 @@ class Ui(QtWidgets.QMainWindow):
         elif not checked:
             self.stream_processor_rpc("stop_zmq_forwarding")
 
-    @QtCore.pyqtSlot()
-    def on_transmitDataPushButton_clicked(self):
+    def transmit_serial_data(self):
         string_to_send = self.transmitDataLineEdit.text()
         if len(string_to_send) == 0:
             return
         bytes_to_send = string_to_send.encode("latin-1").decode("unicode_escape").encode("latin-1")
         self.stream_processor_rpc("transmit_data", bytes_to_send)
+        self.transmitDataLineEdit.clear()
 
     def stream_processor_rpc(self, method: str, *args, **kwargs):
         command = {"method": method, "args": args, "kwargs": kwargs}

--- a/src/splot/splot.ui
+++ b/src/splot/splot.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>823</width>
-    <height>815</height>
+    <height>823</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -263,6 +263,13 @@
                  </widget>
                 </item>
                </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="rawDataViewerPushButton">
+               <property name="text">
+                <string>View raw serial data</string>
+               </property>
               </widget>
              </item>
              <item>
@@ -608,13 +615,6 @@
                  </widget>
                 </item>
                </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="rawDataViewerPushButton">
-               <property name="text">
-                <string>View raw serial data</string>
-               </property>
               </widget>
              </item>
              <item>

--- a/src/splot/stream_processor.py
+++ b/src/splot/stream_processor.py
@@ -191,7 +191,10 @@ class StreamProcessor:
             logger.info("Stopping zmq->serial forwarding")
 
     def transmit_data(self, data: bytes):
-        self.serial_conn.write(data)
+        if type(self.serial_conn) is serial.Serial:
+            self.serial_conn.write(data)
+        elif type(self.serial_conn) is socket.socket:
+            self.serial_conn.sendall(data)
 
     def handle_rpc_requests(self):
         if self.rpc_conn is None:


### PR DESCRIPTION
- hitting enter in serial transmit line edit now sends (and clears box) 
- move raw data viewer button up in panel to more logical position
- fix exception thrown if less than 2 plots visible
- serial transmit now works on sockets as well as serial objects 
- clear button in RawDataViewer now works when paused